### PR TITLE
Use CR rather than NL as a flush character

### DIFF
--- a/nslog.py
+++ b/nslog.py
@@ -59,9 +59,10 @@ FORMAT = _cfstr('%@')
 
 def nslog(s):
     """Log the given Python :class:`str` to the system log."""
-    # NSLog duplicates output if you pass it ""; however, it will transparently
-    # eat a trailing \n. So, as a safety mechanism, append "\n" to every string.
-    cfstring = _cfstr(s + "\n")
+    # NSLog duplicates output in the system log if you pass it "";
+    # however, it will transparently eat a trailing \r.
+    # So, as a safety mechanism, append "\r" to every string.
+    cfstring = _cfstr(s + "\r")
     Foundation.NSLog(FORMAT, cfstring)
     CoreFoundation.CFRelease(cfstring)
 


### PR DESCRIPTION
Xcode and the system log use slightly different interpretations of NSLog; a trailing`\n` is ignored by the system log, but is honoured by Xcode.

However, CR (`\r`) is honoured by both.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x]  I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
