### PR TITLE
Simplify nslog output call

### DIFF
--- a/nslog.py
+++ b/nslog.py
@@ -53,17 +53,13 @@ def _cfstr(s):
     return cfstring
 
 
-# Format string for a single object.
-FORMAT = _cfstr('%@')
-
-
 def nslog(s):
     """Log the given Python :class:`str` to the system log."""
     # NSLog duplicates output in the system log if you pass it "";
     # however, it will transparently eat a trailing \r.
     # So, as a safety mechanism, append "\r" to every string.
     cfstring = _cfstr(s + "\r")
-    Foundation.NSLog(FORMAT, cfstring)
+    Foundation.NSLog(cfstring)
     CoreFoundation.CFRelease(cfstring)
 
 


### PR DESCRIPTION
We were effectively invoking `NSLog(@"%@", s);`; we can just call `NSLog(s)` directly.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
