### PR TITLE
Add GitHub workflow to keep `pre-commit` hooks up-to-date

### DIFF
--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -1,0 +1,12 @@
+name: Update pre-commit
+
+on:
+  schedule:
+    - cron: "0 20 * * SUN"  # Sunday @ 2000 UTC
+  workflow_dispatch:
+
+jobs:
+  pre-commit-update:
+    name: Update pre-commit
+    uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
+    secrets: inherit

--- a/.github/workflows/pre-commit-update.yml
+++ b/.github/workflows/pre-commit-update.yml
@@ -10,3 +10,6 @@ jobs:
     name: Update pre-commit
     uses: beeware/.github/.github/workflows/pre-commit-update.yml@main
     secrets: inherit
+    with:
+      pre-commit-source: "pre-commit"
+      create-changenote: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -10,27 +10,21 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
     # For split_on_trailing_comma. Should be in the release after 5.10.1
-    rev: 12cc5fbd67eebf92eb2213b03c07b138ae1fb448
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
-  - repo: https://github.com/myint/docformatter
-    rev: v1.5.0
-    hooks:
-    - id: docformatter
-      args: [--in-place]
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
     - id: black
       language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-eradicate==1.4.0]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3


### PR DESCRIPTION
~~Waiting on `flake8-eradicate` to be updated for `flake8>=6`~~
~~- https://github.com/wemake-services/flake8-eradicate/pull/271~~

Updated `pre-commit` hooks and dropped support for `flake8-eradicate` due to extended incompatibility with `flake8==6.0.0`.

See beeware/.github#6 for details.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
