### PR TITLE
Bump pre-commit hook for pyupgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: isort
         additional_dependencies: [toml]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]


### PR DESCRIPTION
Automatically bumped `pre-commit` hook for `pyupgrade` and ran the update against the repo.