### PR TITLE
Bump black from 23.9.0 to 23.9.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/psf/black
-    rev: 23.9.0
+    rev: 23.9.1
     hooks:
     - id: black
       language_version: python3


### PR DESCRIPTION
Bumps `pre-commit` hook for `black` from 23.9.0 to 23.9.1 and ran the update against the repo.