### PR TITLE
Bump isort from 5.13.2 to 6.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
     # For split_on_trailing_comma. Should be in the release after 5.10.1
-    rev: 5.13.2
+    rev: 6.0.0
     hooks:
       - id: isort
         additional_dependencies: [toml]


### PR DESCRIPTION
Bumps `pre-commit` hook for `isort` from 5.13.2 to 6.0.0 and ran the update against the repo.