### PR TITLE
Replace flake8/isort/black with ruff for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,9 @@ repos:
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.13
     hooks:
-    - id: black
-      language_version: python3
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.3.0
-    hooks:
-      - id: flake8
+      - id: ruff-check
+        args: [ --fix ]
+      - id: ruff-format

--- a/nslog.py
+++ b/nslog.py
@@ -37,7 +37,8 @@ Foundation = ctypes.CDLL("/System/Library/Frameworks/Foundation.framework/Founda
 CoreFoundation.CFRelease.restype = None
 CoreFoundation.CFRelease.argtypes = [CFTypeRef]
 
-# CFStringRef CFStringCreateWithCharacters(CFAllocatorRef alloc, const UniChar *chars, CFIndex numChars)
+# CFStringRef CFStringCreateWithCharacters(CFAllocatorRef alloc,
+# const UniChar *chars, CFIndex numChars)
 CoreFoundation.CFStringCreateWithCharacters.restype = CFTypeRef
 CoreFoundation.CFStringCreateWithCharacters.argtypes = [
     CFTypeRef,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,25 @@
 requires = ["setuptools>=60"]
 build-backend = "setuptools.build_meta"
 
-[tool.isort]
-profile = "black"
-split_on_trailing_comma = true
-combine_as_imports = true
+[tool.ruff]
+exclude = [
+    "core/src/toga/__init__.pyi"
+]
+
+[tool.ruff.lint]
+# In addition to the default rules, these additional rules will be used:
+extend-select = [
+    "E",      # pycodestyle
+    "W",      # pycodestyle
+    "F",      # pyflakes
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "YTT",    # flake8-2020
+    "ASYNC",  # flake8-async
+    "C4",     # flake8-comprehensions
+    "I",      # isort
+    # The SIM rules are *very* opinionated, and don't necessarily make for better code.
+    # They may be worth occasionally turning on just to see if something could actually
+    # use improvement.
+    # "SIM",    # flake8-simplify
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,8 +42,3 @@ platforms = any
 [options]
 py_modules = nslog
 python_requires = >= 3.7
-
-[flake8]
-max-complexity = 25
-max-line-length = 119
-ignore = E203


### PR DESCRIPTION
Replace flake8/isort/black with ruff for linting
Update precommit config and also replaces flake8 isort and black config with ruff config.
Updated nslog.py to make all the ruff checks pass

Resolve issue #59 

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
