### PR TITLE
Modify encoding of NUL characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * The shim now writes to Apple's unified logging system (`os_log`) instead of the deprecated `NSLog` API. Output written to `stdout` and `stderr` appears in Console.app and `log stream` as before, but is now tagged with the `OS_LOG_TYPE_DEFAULT` and `OS_LOG_TYPE_ERROR` levels respectively, so the two streams can be filtered separately.
 * The `encoding` attribute on the writer is now `"utf-8"` (previously `"utf-16-le"` / `"utf-16-be"`), reflecting the underlying API.
+* Null characters (`\x00`) are now replaced with Java's "Modified UTF-8" encoding (`\xc0\x80`), rather than being silently dropped.
 
 ## 1.0.3 (November 25 2022)
 

--- a/src/nslog.py
+++ b/src/nslog.py
@@ -29,8 +29,10 @@ def nslog(s, level=OS_LOG_TYPE_DEFAULT):
         Defaults to `OS_LOG_TYPE_DEFAULT`.
     """
     # os_log accepts UTF-8 C strings; embedded NULs would truncate the
-    # visible message, so strip them defensively.
-    _oslog_shim.emit(level, s.replace("\x00", "").encode("utf-8"))
+    # visible message, so replace them with Java's "Modified UTF-8"
+    # encoding of U+0000 (this matches what CPython does with the
+    # Apple system logger).
+    _oslog_shim.emit(level, s.replace("\x00", "\xc0\x80").encode("utf-8"))
 
 
 class NSLogWriter(io.TextIOBase):

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -28,6 +28,8 @@ def main(tag) -> None:
     nslog.nslog(f"{tag} explicit info", level=nslog.OS_LOG_TYPE_INFO)
     nslog.nslog(f"{tag} explicit error", level=nslog.OS_LOG_TYPE_ERROR)
 
+    print(f"{tag} string with an \x00 embedded null")
+
     # NSLogWriter buffers partial lines until a newline arrives; flush
     # explicitly so nothing is dropped before the unified-log query runs.
     sys.stdout.flush()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -44,9 +44,11 @@ def test_system_log():
             "this is stderr",
             "explicit info",
             "explicit error",
+            "string with an À embedded null",
         ]
         if f"{tag} {msg}" not in log
     ]
+
     assert not missing, (
         "Expected message(s) not found in `log show` output: "
         + ", ".join(repr(m) for m in missing)

--- a/tox.ini
+++ b/tox.ini
@@ -12,5 +12,5 @@ commands = pre-commit run --all-files --show-diff-on-failure --color=always
 skip_install = True
 dependency_groups = test
 commands =
-    uv pip install --find-links=wheelhouse --no-index --only-binary :all: --pre std-nslog
+    uv pip install --find-links=wheelhouse --no-cache --no-index --only-binary :all: --pre std-nslog
     python -m pytest {posargs:-v tests}


### PR DESCRIPTION
Instead of silently dropping NUL characters, match the handling in CPython's system logger, and replace them with \xc0\x80.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
